### PR TITLE
Add codacy code coverage; update to SCoverage 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To build an assembly and run as a separate process:
 
 For soda-fountain-lib, log output goes to `sbt-test.log`.  Logging is controlled via `soda-fountain-lib/src/test/resources/log4j.properties`.
 
-For test coverage reports, do `sbt clean coverage test coverageReport`.  XML and HTML coverage reports are generated.  Unfortunately due to a bug in scalac, HTML line by line highlighting is broken.
+For test coverage reports, do `sbt coverage test`.  XML and HTML coverage reports are generated.  Unfortunately due to a bug in scalac, HTML line by line highlighting is broken.
 
 The HTML reports do not have line coverage highlighting, due to a bug in ScalaC.
 However, you can get the highlighting through Codacy.com!  To do this, run

--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@ To build an assembly and run as a separate process:
 
 For soda-fountain-lib, log output goes to `sbt-test.log`.  Logging is controlled via `soda-fountain-lib/src/test/resources/log4j.properties`.
 
-For test coverage reports, do `sbt soda-fountain-lib/scoverage:test`.  XML and HTML coverage reports are generated.  Unfortunately due to a bug in scalac, HTML line by line highlighting is broken.
+For test coverage reports, do `sbt clean coverage test coverageReport`.  XML and HTML coverage reports are generated.  Unfortunately due to a bug in scalac, HTML line by line highlighting is broken.
+
+The HTML reports do not have line coverage highlighting, due to a bug in ScalaC.
+However, you can get the highlighting through Codacy.com!  To do this, run
+additional commands `coverageAggregate` and `codacyCoverage`.  Also see [this
+link](http://blog.codacy.com/2015/01/12/introducing-code-coverage) for details.
 
 ## Migrations
 

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -2,6 +2,7 @@ import sbt._
 import Keys._
 
 import com.socrata.cloudbeessbt.SocrataCloudbeesSbt
+import scoverage.ScoverageSbtPlugin
 
 object BuildSettings {
   val buildSettings: Seq[Setting[_]] =
@@ -9,7 +10,8 @@ object BuildSettings {
     spray.revolver.RevolverPlugin.Revolver.settings ++
     Defaults.itSettings ++
       Seq(
-        scalaVersion := "2.10.4"
+        scalaVersion := "2.10.4",
+        ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := false
       )
 
   def projectSettings(assembly: Boolean = false): Seq[Setting[_]] =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,15 +1,20 @@
 resolvers ++= Seq(
     "socrata maven" at "https://repository-socrata-oss.forge.cloudbees.com/release",
-    "DiversIT repo" at "http://repository-diversit.forge.cloudbees.com/release"
+    "DiversIT repo" at "http://repository-diversit.forge.cloudbees.com/release",
+    "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 )
 
-addSbtPlugin("com.socrata" % "socrata-cloudbees-sbt" % "1.3.1")
+addSbtPlugin("com.socrata" % "socrata-cloudbees-sbt" % "1.3.2")
 
 addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.4.2")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.7.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-license-report" % "1.0.0")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.1")
+
+addSbtPlugin("com.codacy" % "sbt-codacy-coverage" % "1.0.0")
 
 libraryDependencies ++= Seq(
   "com.rojoma" %% "simple-arm" % "1.2.0",


### PR DESCRIPTION
Adds the codacy code coverage plugin and updates scoverage to 1.0.1.

NOTE: these are temporary steps to test out code coverage on codacy.  The long term answer is to add the codacy plugin to the autoplugins repo.