### PR TITLE
Don't fall over on high load

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
     val rojomaSimpleArm   = "1.2.0"
     val rojomaSimpleArmV2 = "2.1.0"
     val scalaj            = "0.3.15"
-    val socrataHttp       = "3.2.1-SNAPSHOT"
+    val socrataHttp       = "3.3.0"
     val soqlBrita         = "1.3.0"
     val soqlReference     = "0.5.0"
     val thirdPartyUtils   = "3.0.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
     val rojomaSimpleArm   = "1.2.0"
     val rojomaSimpleArmV2 = "2.1.0"
     val scalaj            = "0.3.15"
-    val socrataHttp       = "3.1.1"
+    val socrataHttp       = "3.2.1-SNAPSHOT"
     val soqlBrita         = "1.3.0"
     val soqlReference     = "0.5.0"
     val thirdPartyUtils   = "3.0.0"

--- a/soda-fountain-jetty/src/main/scala/com/socrata/soda/server/SodaFountainJetty.scala
+++ b/soda-fountain-jetty/src/main/scala/com/socrata/soda/server/SodaFountainJetty.scala
@@ -21,6 +21,7 @@ object SodaFountainJetty extends App {
       SocrataServerJetty.defaultOptions.
         withPort(config.network.port).
         withExtraHandlers(List(SocrataHttpSupport.getHandler(metricsOptions))).
+        withPoolOptions(SocrataServerJetty.Pool(config.threadpool)).
         withBroker(new CuratorBroker[Void](
           discovery,
           config.discovery.address,

--- a/soda-fountain-lib/src/main/resources/reference.conf
+++ b/soda-fountain-lib/src/main/resources/reference.conf
@@ -83,6 +83,14 @@ com.socrata.soda-fountain = {
 #   jms-queue = "MyJMSQueue"
 # }
 
+  threadpool {
+    min-threads = 10
+    max-threads = 100
+    idle-timeout = 30 s
+    # Based on throughput of 50 req/sec * 60 seconds for recovery
+    queue-length = 3000
+  }
+
   log4j {
     rootLogger = [ INFO, console ]
     appender {

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/config/SodaFountainConfig.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/config/SodaFountainConfig.scala
@@ -20,6 +20,7 @@ class SodaFountainConfig(config: Config) extends ConfigClass(WithDefaultAddress(
   val handlers = getRawConfig("handlers")
   val metrics =  optionally(getConfig("metrics", new BalboaConfig(_,_)))
   val codaMetrics = getRawConfig("metrics")
+  val threadpool = getRawConfig("threadpool")
 }
 
 class DataCoordinatorClientConfig(config: Config, root: String) extends ConfigClass(config, root) {


### PR DESCRIPTION
- Use the newer version of socrata-http with bounded queues by default
- Add default config values, which can be overridden