### PR TITLE
Reduce queue length to keep request latency lower

### DIFF
--- a/soda-fountain-lib/src/main/resources/reference.conf
+++ b/soda-fountain-lib/src/main/resources/reference.conf
@@ -92,8 +92,8 @@ com.socrata.soda-fountain = {
     min-threads = 10
     max-threads = 100
     idle-timeout = 30 s
-    # Based on throughput of 50 req/sec * 10 seconds for recovery
-    queue-length = 500
+    # Based on throughput of 50 req/sec * 5 seconds for recovery
+    queue-length = 250
   }
 
   log4j {

--- a/soda-fountain-lib/src/main/resources/reference.conf
+++ b/soda-fountain-lib/src/main/resources/reference.conf
@@ -92,8 +92,8 @@ com.socrata.soda-fountain = {
     min-threads = 10
     max-threads = 100
     idle-timeout = 30 s
-    # Based on throughput of 50 req/sec * 60 seconds for recovery
-    queue-length = 3000
+    # Based on throughput of 50 req/sec * 10 seconds for recovery
+    queue-length = 500
   }
 
   log4j {


### PR DESCRIPTION
At 500, we should be able to keep /version running.  Might have to tune it some more, but better than the previous value.