### PR TITLE
Use WKB for CJSON Geometry types

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
     val scalaj            = "0.3.15"
     val socrataHttp       = "3.3.0"
     val soqlBrita         = "1.3.0"
-    val soqlReference     = "0.5.1-SNAPSHOT"
+    val soqlReference     = "0.5.1"
     val thirdPartyUtils   = "3.0.0"
     val typesafeConfig    = "1.0.2"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
     val scalaj            = "0.3.15"
     val socrataHttp       = "3.3.0"
     val soqlBrita         = "1.3.0"
-    val soqlReference     = "0.5.0"
+    val soqlReference     = "0.5.1-SNAPSHOT"
     val thirdPartyUtils   = "3.0.0"
     val typesafeConfig    = "1.0.2"
 

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/wiremodels/JsonColumnRepPerfBench.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/wiremodels/JsonColumnRepPerfBench.scala
@@ -2,6 +2,7 @@ package com.socrata.soda.server.wiremodels
 
 import com.socrata.soql.types._
 import com.vividsolutions.jts.geom._
+import com.vividsolutions.jts.io.{WKTWriter, WKBWriter}
 
 /**
  * Performance test for JsonColumnRep, specifically for the geometry types input and output.
@@ -37,4 +38,24 @@ object JsonColumnRepPerfBench extends App {
 
   time("JsonColumnRep SoQLPoint fromJValue",
        jValues.map(JsonColumnRep.forClientType(SoQLPoint).fromJValue))
+
+  // WKT or WKB
+  time("JsonColumnRep SoQLPoint CJSON/DC toJValue",
+       sourceSoql.map(JsonColumnRep.forDataCoordinatorType(SoQLPoint).toJValue))
+
+  val dcjValues = sourceSoql.map(JsonColumnRep.forDataCoordinatorType(SoQLPoint).toJValue)
+
+  time("JsonColumnRep SoQLPoint CJSON/DC fromJValue",
+       dcjValues.map(JsonColumnRep.forDataCoordinatorType(SoQLPoint).fromJValue))
+
+  val wktWriter = new WKTWriter
+  val wkbWriter = new WKBWriter
+  // See http://java-performance.info/base64-encoding-and-decoding-performance/
+  import javax.xml.bind.DatatypeConverter.printBase64Binary
+
+  time("Point to WKT", sourcePoints.map(wktWriter.write))
+  time("Point to WKB", sourcePoints.map(wkbWriter.write))
+  time("Point to base64(WKB)", sourcePoints.map(pt => printBase64Binary(wkbWriter.write(pt))))
+
+
 }

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/wiremodels/JsonColumnRepTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/wiremodels/JsonColumnRepTest.scala
@@ -139,4 +139,18 @@ class JsonColumnRepTest extends FunSuite with MustMatchers with Assertions {
     val outJvalue = JsonColumnRep.forClientType(SoQLPoint).toJValue(pt)
     JsonColumnRep.forClientType(SoQLPoint).fromJValue(outJvalue) must equal (Some(pt))
   }
+
+  test("can read from CJSON WKT and WKB64") {
+    val wkb64 = "AAAAAAHAPgpa8K4hcEBITaQDgJ5U"
+    val wkt = "POINT (-30.04045 48.606567)"
+    val soqlPointFromWkb = JsonColumnRep.forDataCoordinatorType(SoQLPoint)
+                             .fromJValue(JString(wkb64)).get.asInstanceOf[SoQLPoint]
+    soqlPointFromWkb.value.getX must be { -30.04045 +- 0.000001 }
+    soqlPointFromWkb.value.getY must be { 48.606567 +- 0.000001 }
+
+    val soqlPointFromWkt = JsonColumnRep.forDataCoordinatorType(SoQLPoint)
+                             .fromJValue(JString(wkt)).get.asInstanceOf[SoQLPoint]
+    soqlPointFromWkt.value.getX must be { -30.04045 +- 0.000001 }
+    soqlPointFromWkt.value.getY must be { 48.606567 +- 0.000001 }
+  }
 }


### PR DESCRIPTION
Speed up CJSON serialization by writing and reading geometries as base64 WKB.   For compatibility purposes, the decoder will fall back to WKT (so that we can upgrade SF before ugprading PG server).

Add more stuff to a perf benchmark.

NOT READY FOR MERGE yet.  Need to publish and release soql-reference PR first.