### PR TITLE
New SoQLPack Binary Protocol

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -12,7 +12,9 @@ object BuildSettings {
         // TODO: enable style checks
         styleCheck in Test := {},
         styleCheck in Compile := {},
-        scalaVersion := "2.10.4"
+        scalaVersion := "2.10.4",
+
+        resolvers += "velvia maven" at "http://dl.bintray.com/velvia/maven"
       )
 
   def projectSettings(assembly: Boolean = false): Seq[Setting[_]] =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,6 +13,7 @@ object Dependencies {
     val log4j             = "1.2.16"
     val metricsScala      = "3.3.0"
     val mortbayJetty      = "6.1.22"
+    val msgpack4s         = "0.4.2"
     val postgresql        = "9.1-901-1.jdbc4"
     val quasiQuotes       = "2.0.0"
     val rojomaJson        = "3.2.2"
@@ -54,6 +55,8 @@ object Dependencies {
   val log4j                    = "log4j"            % "log4j"                       % versions.log4j
 
   val metricsScala             = "nl.grons"        %% "metrics-scala"               % versions.metricsScala
+
+  val msgpack4s                = "org.velvia"      %% "msgpack4s"                   % versions.msgpack4s
 
   val mortbayJetty             = "org.mortbay.jetty" % "jetty"                      % versions.mortbayJetty % "container"
 

--- a/project/SodaFountainLib.scala
+++ b/project/SodaFountainLib.scala
@@ -21,6 +21,7 @@ object SodaFountainLib {
       liquibasePlugin,
       log4j,
       metricsScala,
+      msgpack4s,
       postgresql,
       rojomaSimpleArm,
       rojomaSimpleArmV2,

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/Exporter.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/Exporter.scala
@@ -16,7 +16,7 @@ trait Exporter {
 }
 
 object Exporter {
-  val exporters = List(JsonExporter, CJsonExporter, CsvExporter, GeoJsonExporter)
+  val exporters = List(JsonExporter, CJsonExporter, CsvExporter, GeoJsonExporter, SoQLPackExporter)
   val exportForMimeType = exporters.map { e => e.mimeType -> e }.toMap
   val exporterExtensions = exporters.flatMap(_.extension).map(canonicalizeExtension).toSet
 

--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/SoQLPackExporter.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/server/export/SoQLPackExporter.scala
@@ -1,0 +1,104 @@
+package com.socrata.soda.server.export
+
+import com.rojoma.simplearm.util._
+import com.socrata.http.common.util.AliasedCharset
+import com.socrata.soda.server.highlevel.ExportDAO
+import com.socrata.soda.server.highlevel.ExportDAO.ColumnInfo
+import com.socrata.soda.server.util.AdditionalJsonCodecs._
+import com.socrata.soda.server.wiremodels.{JsonColumnRep, JsonColumnWriteRep}
+import com.socrata.soql.types._
+import com.vividsolutions.jts.io.WKBWriter
+import java.io.DataOutputStream
+import javax.activation.MimeType
+import javax.servlet.http.HttpServletResponse
+import org.velvia.MsgPack
+
+/**
+ * Exports in SoQLPack format - an efficient, MessagePack-based SoQL transport medium.
+ *   - Much more efficient than CJSON, GeoJSON, etc... especially for geometries
+ *   - Designed to be very streaming friendly
+ *   - MessagePack format means easier to implement clients in any language
+ *
+ * The structure of the content is pretty much identical to CJSON,
+ * but framed as follows:
+ *   +0000  P bytes - CJSON-like header, MessagePack object/map, currently with the following entries:
+ *                        "row_count" -> integer count of rows
+ *                        "geometry_index" -> index within row of geometry shape
+ *                        "schema" -> MsgPack equiv of [{"c": fieldName1, "t": fieldType1}, ...]
+ *   +P     R bytes - first row - MessagePack array
+ *                        geometries are WKB binary blobs
+ *                        Text fields are strings
+ *                        Number fields are numbers
+ *                        All other fields... TBD
+ *   +P+R           - second row
+ *   All other rows are encoded as MessagePack arrays and follow sequentially.
+ *
+ *   NOTE: Unlike CJSON, the columns are not rearranged in alphabetical field order, but the original
+ *   order in the Array[SoQLValue] and CSchema are retained.
+ */
+object SoQLPackExporter extends Exporter {
+  // Technically we could use "application/x-msgpack", but this is not entirely pure messagepack
+  // to aid in streaming.
+  val mimeTypeBase = "application/octet-stream"
+  val mimeType = new MimeType(mimeTypeBase)
+  val extension = Some("soqlpack")
+
+  private def getGeoColumnIndex(columns: Seq[ColumnInfo]): Int = {
+    val geoColumnIndices = columns.zipWithIndex.collect {
+      case (columnInfo, index) if columnInfo.typ.isInstanceOf[SoQLGeometryLike[_]] => index
+    }
+
+    // Just return -1 if no geo column or more than one
+    if (geoColumnIndices.size != 1) return -1
+
+    geoColumnIndices(0)
+  }
+
+  def export(resp: HttpServletResponse, charset: AliasedCharset, schema: ExportDAO.CSchema, rows: Iterator[Array[SoQLValue]], singleRow: Boolean = false) {
+    val mt = new MimeType(mimeTypeBase)
+    resp.setContentType(mt.toString)
+    for {
+      os <- managed(resp.getOutputStream)
+      dos <- managed(new DataOutputStream(os))
+    } yield {
+      val geoColumn = getGeoColumnIndex(schema.schema)
+
+      val rowCountElem: Option[(String, Long)] = schema.rowCount.map { count => "row_count" -> count }
+      val geoIndexElem = Some("geometry_index" -> geoColumn)
+
+      val schemaMaps = schema.schema.map { ci =>
+        Map("c" -> ci.fieldName.name, "t" -> ci.typ.toString)
+      }.toSeq
+
+      val headerMap: Map[String, Any] = Seq[Option[(String, Any)]](
+                                          rowCountElem,
+                                          geoIndexElem,
+                                          Some("schema" -> schemaMaps)).flatten.toMap
+      MsgPack.pack(headerMap, dos)
+
+      // end of header
+
+      val wkbWriter = new WKBWriter
+
+      val reps: Array[JsonColumnWriteRep] = schema.schema.map { ci => JsonColumnRep.forClientType(ci.typ) }.toArray
+      for (row <- rows) {
+        val values: Seq[Any] = (0 until row.length).map { i =>
+          // TODO: turn this logic into a MessagePackColumnRep
+          row(i) match {
+            case SoQLPoint(pt)       => wkbWriter.write(pt)
+            case SoQLMultiLine(ml)   => wkbWriter.write(ml)
+            case SoQLMultiPolygon(p) => wkbWriter.write(p)
+            case SoQLText(str)       => str
+            case SoQLNull            => null
+            case null                => null
+            case SoQLBoolean(bool)   => bool
+            // For anything else, we rely on the JsonColumnRep and translate from JValues
+            case other: SoQLValue    => ???
+          }
+        }
+        MsgPack.pack(values, dos)
+      }
+      dos.flush()
+    }
+  }
+}

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/export/SoQLPackDumper.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/export/SoQLPackDumper.scala
@@ -6,19 +6,15 @@ import org.velvia.MsgPackUtils._
 import com.vividsolutions.jts.io.WKBReader
 
 /**
- * App that takes a SoQLPack binary file and dumps out the header and rows
+ * App that takes a SoQLPack stream from STDIN and dumps out the header and rows
  * This should be moved into part of the main instead of test package, but this would
  * mess up the java -jar soda-fountain-assembly experience...
  *
  * Run in the soda-fountain directory like:
- *   sbt 'soda-fountain-lib/test:run com.socrata.soda.server.export.SoQLPackDumper /tmp/soqlpack.in'
- *
- * Sorry wanted to make this work on STDIN but SBT is not cooperating.  Fix this once we
- * fix the SBT assembly issue.
+ *  curl ... | sbt 'soda-fountain-lib/test:runMain com.socrata.soda.server.export.SoQLPackDumper'
  */
 object SoQLPackDumper extends App {
-  // val dis = new DataInputStream(System.in)
-  val dis = new DataInputStream(new FileInputStream(args(0)))
+  val dis = new DataInputStream(System.in)
   val headerMap = MsgPack.unpack(dis, MsgPack.UNPACK_RAW_AS_STRING).asInstanceOf[Map[String, Any]]
   println("--- Schema ---")
   headerMap.foreach { case (key, value) => println("%25s: %s".format(key, value)) }

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/export/SoQLPackDumper.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/export/SoQLPackDumper.scala
@@ -1,0 +1,47 @@
+package com.socrata.soda.server.export
+
+import java.io.{DataInputStream, FileInputStream}
+import org.velvia.MsgPack
+import org.velvia.MsgPackUtils._
+import com.vividsolutions.jts.io.WKBReader
+
+/**
+ * App that takes a SoQLPack binary file and dumps out the header and rows
+ * This should be moved into part of the main instead of test package, but this would
+ * mess up the java -jar soda-fountain-assembly experience...
+ *
+ * Run in the soda-fountain directory like:
+ *   sbt 'soda-fountain-lib/test:run com.socrata.soda.server.export.SoQLPackDumper /tmp/soqlpack.in'
+ *
+ * Sorry wanted to make this work on STDIN but SBT is not cooperating.  Fix this once we
+ * fix the SBT assembly issue.
+ */
+object SoQLPackDumper extends App {
+  // val dis = new DataInputStream(System.in)
+  val dis = new DataInputStream(new FileInputStream(args(0)))
+  val headerMap = MsgPack.unpack(dis, MsgPack.UNPACK_RAW_AS_STRING).asInstanceOf[Map[String, Any]]
+  println("--- Schema ---")
+  headerMap.foreach { case (key, value) => println("%25s: %s".format(key, value)) }
+  val types = headerMap.as[Seq[Map[String, String]]]("schema").map { m => m("t") }
+
+  println("\n---")
+
+  val reader = new WKBReader
+
+  while (dis.available > 0) {
+    // Don't unpack raw byte arrays as Strings - they might be Geometries or other blobs
+    val row = MsgPack.unpack(dis, 0).asInstanceOf[Seq[Any]]
+    for (i <- 0 until row.length) {
+      if (Set("point", "multiline", "multipolygon") contains types(i)) {
+        print(reader.read(row(i).asInstanceOf[Array[Byte]]))
+      } else if (types(i) == "text") {
+        print(new String(row(i).asInstanceOf[Array[Byte]]))
+      } else {
+        print(row(i).toString)
+      }
+      print(", ")
+    }
+    println
+  }
+
+}

--- a/soda-fountain-lib/src/test/scala/com/socrata/soda/server/export/SoQLPackExporterTest.scala
+++ b/soda-fountain-lib/src/test/scala/com/socrata/soda/server/export/SoQLPackExporterTest.scala
@@ -1,0 +1,175 @@
+package com.socrata.soda.server.export
+
+import com.rojoma.simplearm.util._
+import com.rojoma.json.v3.ast._
+import com.rojoma.json.v3.io.JsonReader
+import com.socrata.http.common.util.AliasedCharset
+import com.socrata.soda.server.DatasetsForTesting
+import com.socrata.soda.server.highlevel.{ExportDAO, CJson}
+import com.socrata.soda.server.highlevel.ExportDAO.ColumnInfo
+import com.socrata.soda.server.id.ColumnId
+import com.socrata.soda.server.persistence.ColumnRecord
+import com.socrata.soda.server.wiremodels.JsonColumnRep
+import com.socrata.soql.environment.ColumnName
+import com.socrata.soql.types._
+import java.io.{ByteArrayOutputStream, ByteArrayInputStream, DataInputStream}
+import java.nio.charset.StandardCharsets
+import javax.servlet.ServletOutputStream
+import javax.servlet.http.HttpServletResponse
+import org.joda.time.format.ISODateTimeFormat
+import org.scalamock.proxy.ProxyMockFactory
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{FunSuite, Matchers}
+import org.velvia.MsgPack
+import org.velvia.MsgPackUtils._
+
+class SoQLPackExporterTest  extends FunSuite with MockFactory with ProxyMockFactory with Matchers with DatasetsForTesting {
+  val charset = AliasedCharset(StandardCharsets.UTF_8, StandardCharsets.UTF_8.name)
+
+  test("Multi row - dataset with single geo column") {
+    val columns = Seq(
+      new ColumnRecord(ColumnId("hym8-ivsj"), ColumnName("name"), SoQLText, "name", "", false, None),
+      new ColumnRecord(ColumnId("pw2s-k39x"), ColumnName("location"), SoQLPoint, "location", "", false, None)
+    )
+
+    val rows = Seq[Array[SoQLValue]](
+      Array(SoQLText("Volunteer Park"), SoQLPoint(SoQLPoint.WktRep.unapply("POINT (-122.314822 47.630269)").get)),
+      Array(SoQLText("Cal Anderson Park"), SoQLPoint(SoQLPoint.WktRep.unapply("POINT (-122.319071 47.617296)").get)),
+      Array(SoQLText("Seward Park"), SoQLPoint(SoQLPoint.WktRep.unapply("POINT (-122.252513 47.555530)").get))
+    )
+
+    val (header, outRows) = getSoQLPack(columns, "hym8-ivsj", rows, false)
+
+    header.asInt("geometry_index") should be (1)
+    outRows should have length (3)
+    getStringFrom(outRows(2), 0) should equal ("Seward Park")
+    getXYFromRowGeom(outRows(0), 1) should equal ((-122.314822, 47.630269))
+  }
+
+  test("Single row - dataset with single geo column") {
+    val columns = Seq(
+      new ColumnRecord(ColumnId("hym8-ivsj"), ColumnName("name"), SoQLText, "name", "", false, None),
+      new ColumnRecord(ColumnId("pw2s-k39x"), ColumnName("location"), SoQLPoint, "location", "", false, None)
+    )
+
+    val rows = Seq[Array[SoQLValue]](
+      Array(SoQLText("Volunteer Park"), SoQLPoint(SoQLPoint.WktRep.unapply("POINT (-122.314822 47.630269)").get))
+    )
+
+    val (header, outRows) = getSoQLPack(columns, "hym8-ivsj", rows, true)
+    header.asInt("geometry_index") should be (1)
+    outRows should have length (1)
+    getStringFrom(outRows(0), 0) should equal ("Volunteer Park")
+    getXYFromRowGeom(outRows(0), 1) should equal ((-122.314822, 47.630269))
+  }
+
+  test("Single row - dataset with null geo column") {
+    val columns = Seq(
+      new ColumnRecord(ColumnId("hym8-ivsj"), ColumnName("name"), SoQLText, "name", "", false, None),
+      new ColumnRecord(ColumnId("pw2s-k39x"), ColumnName("location"), SoQLPoint, "location", "", false, None)
+    )
+
+    val rows = Seq[Array[SoQLValue]](
+      Array(SoQLText("Volunteer Park"), SoQLNull)
+    )
+
+    val (header, outRows) = getSoQLPack(columns, "hym8-ivsj", rows, true)
+    header.asInt("geometry_index") should be (1)
+    outRows should have length (1)
+    Option(outRows(0)(1)) should be (None)
+  }
+
+
+  test("Multi row - dataset with single geo column and some rows with empty geo value") {
+    val columns = Seq(
+      new ColumnRecord(ColumnId("hym8-ivsj"), ColumnName("name"), SoQLText, "name", "", false, None),
+      new ColumnRecord(ColumnId("pw2s-k39x"), ColumnName("location"), SoQLPoint, "location", "", false, None)
+    )
+
+    val rows = Seq[Array[SoQLValue]](
+      Array(SoQLText("Volunteer Park"), SoQLPoint(SoQLPoint.WktRep.unapply("POINT (-122.314822 47.630269)").get)),
+      Array(SoQLText("Cal Anderson Park"), SoQLPoint(SoQLPoint.WktRep.unapply("POINT (-122.319071 47.617296)").get)),
+      Array(SoQLText("Phantom Park"), null),
+      Array(SoQLText("Seward Park"), SoQLPoint(SoQLPoint.WktRep.unapply("POINT (-122.252513 47.555530)").get))
+    )
+
+    val (header, outRows) = getSoQLPack(columns, "hym8-ivsj", rows, false)
+
+    header.asInt("geometry_index") should be (1)
+    outRows should have length (4)
+    getStringFrom(outRows(3), 0) should equal ("Seward Park")
+    getXYFromRowGeom(outRows(0), 1) should equal ((-122.314822, 47.630269))
+    Option(outRows(2)(1)) should be (None)
+  }
+
+  private def getXYFromRowGeom(row: Seq[Any], index: Int): (Double, Double) = {
+    val bytes = row(index).asInstanceOf[Array[Byte]]
+    val pt = SoQLPoint.WkbRep.unapply(bytes).get
+    (pt.getX, pt.getY)
+  }
+
+  private def getStringFrom(row: Seq[Any], index: Int): String =
+    new String(row(index).asInstanceOf[Array[Byte]])
+
+  private def getSoQLPack(columns: Seq[ColumnRecord],
+                         pk: String,
+                         rows: Seq[Array[SoQLValue]],
+                         singleRow: Boolean): (Map[String, Any], Seq[Seq[Any]]) = {
+    for { baos   <- managed(new ByteArrayOutputStream)
+          stream <- managed(new ServletOutputStream { def write(b: Int) { baos.write(b) }} ) } yield {
+      val mockResponse = mock[HttpServletResponse]
+      mockResponse.expects('setContentType)("application/octet-stream")
+      mockResponse.expects('getOutputStream)().returning(stream)
+
+      SoQLPackExporter.export(mockResponse, charset, getDCSchema(columns, pk, rows), rows.iterator, singleRow)
+
+      val dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray))
+      val headerMap = MsgPack.unpack(dis, MsgPack.UNPACK_RAW_AS_STRING).asInstanceOf[Map[String, Any]]
+      val outRows = new collection.mutable.ArrayBuffer[Seq[Any]]
+      while (dis.available > 0) {
+        outRows += MsgPack.unpack(dis, 0).asInstanceOf[Seq[Any]]
+      }
+      (headerMap, outRows)
+    }
+  }
+
+  // TODO: extract these functions and the ones in GeoJsonExporterTest into common ExporterTest trait
+  private def getDCSchema(columns: Seq[ColumnRecord], pk: String, rows: Seq[Array[SoQLValue]]): ExportDAO.CSchema = {
+    val dcInfo = Iterator.single[JValue](getDCSummary(columns, pk, rows.size)) ++ getDCRows(rows)
+    val decoded: CJson.Schema = CJson.decode(dcInfo) match {
+      case CJson.Decoded(schema, rows) => schema
+      case _ => fail("Something got messed up here")
+    }
+
+    val dataset = generateDataset("GeoJsonExporterTest", columns)
+
+    ExportDAO.CSchema(decoded.approximateRowCount,
+      decoded.dataVersion,
+      decoded.lastModified.map(time => ISODateTimeFormat.dateTimeParser.parseDateTime(time)),
+      decoded.locale,
+      decoded.pk.map(dataset.columnsById(_).fieldName),
+      decoded.rowCount,
+      decoded.schema.map {
+        f => ColumnInfo(dataset.columnsById(f.c).id, dataset.columnsById(f.c).fieldName, dataset.columnsById(f.c).name, f.t)
+      })
+  }
+
+  private def getDCRows(rows: Seq[Array[SoQLValue]]) = {
+    val jValues = rows.map(_.map { cell =>
+      JsonColumnRep.forDataCoordinatorType(cell.typ).toJValue(cell)
+    })
+    jValues.map(JArray(_))
+  }
+
+  private def getDCSummary(columns: Seq[ColumnRecord], pk: String, rowCount: Int) = {
+    val dcRowSchema = columns.map { column =>
+      JObject(Map("c" -> JString(column.id.underlying), "t" -> JString(getHumanReadableTypeName(column.typ))))
+    }
+    JObject(Map("approximate_row_count" -> JNumber(rowCount),
+                "locale"                -> JString("en_US"),
+                "pk"                    -> JString(pk),
+                "schema"                -> JArray(dcRowSchema)))
+  }
+
+  private def getHumanReadableTypeName(typ: SoQLType) = SoQLType.typesByName.map(_.swap).get(typ).get.name
+}


### PR DESCRIPTION
You can read about the details in SoQLPackExporter.scala, but this is a new, binary, highly efficient export protocol.  Initially only geometry, text, boolean columns are supported, which is enough for minimal tests and the tile server.

A tool to aid in debugging SoQLPack output is also included.