### PR TITLE
Log upsert progress

### DIFF
--- a/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/MutationScript.scala
+++ b/soda-fountain-lib/src/main/scala/com/socrata/soda/clients/datacoordinator/MutationScript.scala
@@ -11,7 +11,7 @@ class MutationScript(
         user: String,
         copyInstruction: DatasetCopyInstruction,
         instructions: Iterator[DataCoordinatorInstruction],
-        reportingInterval: Int = 10000){
+        reportingInterval: Int = 50000){
   val log = LoggerFactory.getLogger(getClass)
 
   def it : Iterator[JsonEvent] = {


### PR DESCRIPTION
This logs upserts every 50,000 instructions to make it easier to debug/track progress for both ingress and compute routes.